### PR TITLE
Fix order of multipleInstructions when NOP padding

### DIFF
--- a/src/test/scala/RISCV/Parser.scala
+++ b/src/test/scala/RISCV/Parser.scala
@@ -228,7 +228,7 @@ object Parser {
       def addOps      (t: List[SourceInfo[Op]]): FoldHelper = {
         if(testOptions.nopPadded){
           copy(
-            ops = t.flatMap(x => (x :: List.fill(4)(SourceInfo("inserted NOP", NOP).widen[Op]))).reverse ::: ops,
+            ops = t.flatMap(x => (x :: List.fill(4)(SourceInfo("inserted NOP", NOP).widen[Op])).reverse) ::: ops,
             addrCount = addrCount + t.size*4*5)
         }
         else {


### PR DESCRIPTION
Make sure that expanded multipleInstructions are in correct order.

Example for LI that's expanded to LUI->ADDI.
Old behavior:
nop, nop, nop, nop, ADDI
nop, nop, nop, nop, LUI

New behaviour:
nop, nop, nop, nop, LUI
nop, nop, nop, nop, ADDI