### PR TITLE
Fix missmatching file name

### DIFF
--- a/theory2.org
+++ b/theory2.org
@@ -271,7 +271,7 @@
    For this task it is necessary to use something more sophisticated than ~Map[(Int, Boolean)]~ to represent
    your branch predictor model.
 
-   The skeleton code is located in ~testRunner.scala~ and can be run using testOnly FiveStage.ProfileBranching.
+   The skeleton code is located in ~branchProfiler.scala~ and can be run using testOnly FiveStage.ProfileBranching.
 
    With a 2 bit 8 slot scheme, how many mispredicts will happen?
    Answer with a number.


### PR DESCRIPTION
The skeleton code for exercise 4 has been moved to branchProfiling.scala