### PR TITLE
add functionality to run only basic tests

### DIFF
--- a/src/test/scala/Manifest.scala
+++ b/src/test/scala/Manifest.scala
@@ -71,8 +71,31 @@ class ProfileCache extends FlatSpec with Matchers {
 }
 
 class SingleTest extends FlatSpec with Matchers {
-  it should "just werk" in {
+  it should "just work" in {
     TestRunner.run(Manifest.singleTestOptions) should be(true)
+  }
+}
+
+// Test by command: "testOnly FiveStage.AllBasicTests"
+class AllBasicTests extends FlatSpec with Matchers {
+  it should "just work" in {
+    val works = getAllBasicNames.filterNot(_ == "convolution.s").map{testname =>
+      say(s"testing basic $testname")
+      val opts = Manifest.allTestOptions(testname)
+      (testname, TestRunner.run(opts))
+    }
+    if(works.foldLeft(true)(_ && _._2))
+      say(Console.GREEN + "All tests successful!" + Console.RESET)
+    else {
+      val success = works.map(x => if(x._2) 1 else 0).sum
+      val total   = works.size
+      say(s"$success/$total tests successful")
+      works.foreach{ case(name, success) =>
+        val msg = if(success) Console.GREEN + s"$name successful" + Console.RESET
+        else Console.RED + s"$name failed" + Console.RESET
+        say(msg)
+      }
+    }
   }
 }
 

--- a/src/test/scala/fileUtils.scala
+++ b/src/test/scala/fileUtils.scala
@@ -58,10 +58,18 @@ object fileUtils {
   def getTestDir: File =
     new File(getClass.getClassLoader.getResource("tests").getPath)
 
+  def getBasicDir: File =
+    new File(getClass.getClassLoader.getResource("tests/basic").getPath)
+
   def getAllTests: List[File] = getListOfFilesRecursive(getTestDir.getPath)
       .filter( f => f.getPath.endsWith(".s") )
 
+  def getAllBasic: List[File] = getListOfFilesRecursive(getBasicDir.getPath)
+      .filter( f => f.getPath.endsWith(".s") )
+
   def getAllTestNames: List[String]        = getAllTests.map(_.toString.split("/").takeRight(1).mkString)
+
+  def getAllBasicNames: List[String]       = getAllBasic.map(_.toString.split("/").takeRight(1).mkString)
 
   // Not tested.
   def getAllWindowsTestNames: List[String] = getAllTests.map(_.toString.split("\\\\").takeRight(1).mkString)


### PR DESCRIPTION
Added functionality to run only the basic test, by command:

```testOnly FiveStage.AllBasicTests```

Although a downside is that the basic tests seem to be run twice, when just using `test` ...